### PR TITLE
Add schemas for WP REST API taxonomies

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,8 @@ The WordPress REST API response doesn't fully adhere to the JSON schema spec, so
 * In `tests/mu-plugins/mu-plugin.php` add a new `json-dump` command for the new endpoint
   - Start by copy-pasting an existing command such as the `json-dump post` one for `/wp/v2/posts`
   - The command should perform a REST API request to the endpoint and pass the result to the `save()` function which saves it as JSON during the tests
-* In `package.json` add two entries to the `test` script if one doesn't already exist:
+* In `package.json` add a new `"test-{object-type}"` entry to `scripts` if one doesn't already exist.
+* In `composer.json` add two entries to the `test` script if one doesn't already exist:
   - `"wp json-dump {object-type}"`
   - `"npm run test-{object-type}"`
 * Run `composer run test` to validate and test the schemas.

--- a/composer.json
+++ b/composer.json
@@ -50,8 +50,8 @@
 			"wp json-dump search-results",
 			"npm run test-rest-api-search-results",
 			"npm run test-rest-api-posts",
-			"wp json-dump taxonomy",
-			"npm run test-rest-api-taxonomy"
+			"wp json-dump taxonomies",
+			"npm run test-rest-api-taxonomies"
 		]
 	},
 	"funding": [

--- a/composer.json
+++ b/composer.json
@@ -47,9 +47,9 @@
 			"npm run test-error",
 			"wp json-dump user",
 			"npm run test-user",
-			"wp json-dump search-result",
-			"npm run test-rest-api-search-result",
-			"npm run test-rest-api-post"
+			"wp json-dump search-results",
+			"npm run test-rest-api-search-results",
+			"npm run test-rest-api-posts"
 		]
 	},
 	"funding": [

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,9 @@
 			"npm run test-user",
 			"wp json-dump search-result",
 			"npm run test-rest-api-search-result",
-			"npm run test-rest-api-post"
+			"npm run test-rest-api-post",
+			"wp json-dump taxonomy",
+			"npm run test-rest-api-taxonomy"
 		]
 	},
 	"funding": [

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 		"test-error": "ajv validate -m tests/hyper-schema.json -s schemas/error.json -d \"tests/data/error/*.json\" -r \"schemas/**/*.json\"",
 		"test-rest-api-posts": "ajv validate -m tests/hyper-schema.json -s schemas/rest-api/posts.json -d \"tests/data/rest-api/posts/*.json\" -r \"schemas/**/*.json\"",
 		"test-rest-api-search-results": "ajv validate -m tests/hyper-schema.json -s schemas/rest-api/search-results.json -d \"tests/data/rest-api/search-results/*.json\" -r \"schemas/**/*.json\"",
-		"test-rest-api-taxonomy": "ajv validate -m tests/hyper-schema.json -s schemas/rest-api/taxonomy.json -d \"tests/data/rest-api/taxonomy/*.json\" -r \"schemas/**/*.json\"",
+		"test-rest-api-taxonomies": "ajv validate -m tests/hyper-schema.json -s schemas/rest-api/taxonomies.json -d \"tests/data/rest-api/taxonomies/*.json\" -r \"schemas/**/*.json\"",
 		"validate": "ajv compile -m tests/hyper-schema.json -s schema.json -r \"schemas/**/*.json\""
 	}
 }

--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
 		"test-category": "ajv validate -m tests/hyper-schema.json -s schemas/term.json -d \"tests/data/category/*.json\" -r \"schemas/**/*.json\"",
 		"test-comment": "ajv validate -m tests/hyper-schema.json -s schemas/comment.json -d \"tests/data/comment/*.json\" -r \"schemas/**/*.json\"",
 		"test-error": "ajv validate -m tests/hyper-schema.json -s schemas/error.json -d \"tests/data/error/*.json\" -r \"schemas/**/*.json\"",
-		"test-rest-api-post": "ajv validate -m tests/hyper-schema.json -s schemas/rest-api/post.json -d \"tests/data/rest-api/post/*.json\" -r \"schemas/**/*.json\"",
-		"test-rest-api-search-result": "ajv validate -m tests/hyper-schema.json -s schemas/rest-api/search-result.json -d \"tests/data/rest-api/search-result/*.json\" -r \"schemas/**/*.json\"",
+		"test-rest-api-posts": "ajv validate -m tests/hyper-schema.json -s schemas/rest-api/posts.json -d \"tests/data/rest-api/posts/*.json\" -r \"schemas/**/*.json\"",
+		"test-rest-api-search-results": "ajv validate -m tests/hyper-schema.json -s schemas/rest-api/search-results.json -d \"tests/data/rest-api/search-results/*.json\" -r \"schemas/**/*.json\"",
 		"validate": "ajv compile -m tests/hyper-schema.json -s schema.json -r \"schemas/**/*.json\""
 	}
 }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
 		"test-error": "ajv validate -m tests/hyper-schema.json -s schemas/error.json -d \"tests/data/error/*.json\" -r \"schemas/**/*.json\"",
 		"test-rest-api-post": "ajv validate -m tests/hyper-schema.json -s schemas/rest-api/post.json -d \"tests/data/rest-api/post/*.json\" -r \"schemas/**/*.json\"",
 		"test-rest-api-search-result": "ajv validate -m tests/hyper-schema.json -s schemas/rest-api/search-result.json -d \"tests/data/rest-api/search-result/*.json\" -r \"schemas/**/*.json\"",
+		"test-rest-api-taxonomy": "ajv validate -m tests/hyper-schema.json -s schemas/rest-api/taxonomy.json -d \"tests/data/rest-api/taxonomy/*.json\" -r \"schemas/**/*.json\"",
 		"validate": "ajv compile -m tests/hyper-schema.json -s schema.json -r \"schemas/**/*.json\""
 	}
 }

--- a/packages/wp-types/index.ts
+++ b/packages/wp-types/index.ts
@@ -61,10 +61,6 @@ export type WP_REST_API_Users = WP_REST_API_User[];
  * A collection of search result objects in a REST API context.
  */
 export type WP_REST_API_Search_Results = WP_REST_API_Search_Result[];
-/**
- * A collection of taxonomy objects in a REST API context.
- */
-export type WP_REST_API_Taxonomies = WP_REST_API_Taxonomy[];
 
 /**
  * WordPress is open source software you can use to create a beautiful website, blog, or app.
@@ -1948,6 +1944,12 @@ export interface WP_REST_API_Taxonomy {
 	};
 	_links?: WP_REST_API_Object_Links;
 	[k: string]: unknown;
+}
+/**
+ * A collection of taxonomy objects in a REST API context.
+ */
+export interface WP_REST_API_Taxonomies {
+	[k: string]: WP_REST_API_Taxonomy;
 }
 /**
  * A REST API error response.

--- a/packages/wp-types/index.ts
+++ b/packages/wp-types/index.ts
@@ -61,6 +61,10 @@ export type WP_REST_API_Users = WP_REST_API_User[];
  * A collection of search result objects in a REST API context.
  */
 export type WP_REST_API_Search_Results = WP_REST_API_Search_Result[];
+/**
+ * A collection of taxonomy objects in a REST API context.
+ */
+export type WP_REST_API_Taxonomies = WP_REST_API_Taxonomy[];
 
 /**
  * WordPress is open source software you can use to create a beautiful website, blog, or app.
@@ -96,6 +100,8 @@ export interface WP {
 		Users: WP_REST_API_Users;
 		Search_Result: WP_REST_API_Search_Result;
 		Search_Results: WP_REST_API_Search_Results;
+		Taxonomy: WP_REST_API_Taxonomy;
+		Taxonomies: WP_REST_API_Taxonomies;
 		Error: WP_REST_API_Error;
 	};
 }
@@ -1865,6 +1871,82 @@ export interface WP_REST_API_Search_Result {
 	 */
 	subtype: WP_Post_Type_Name | WP_Taxonomy_Name | string;
 	_links: WP_REST_API_Object_Links;
+	[k: string]: unknown;
+}
+/**
+ * A taxonomy in a REST API context.
+ */
+export interface WP_REST_API_Taxonomy {
+	/**
+	 * All capabilities used by the taxonomy.
+	 */
+	capabilities?: {
+		[k: string]: unknown;
+	};
+	/**
+	 * A human-readable description of the taxonomy.
+	 */
+	description: string;
+	/**
+	 * Whether or not the taxonomy should have children.
+	 */
+	hierarchical: boolean;
+	/**
+	 * Human-readable labels for the taxonomy for various contexts.
+	 */
+	labels?: {
+		[k: string]: unknown;
+	};
+	/**
+	 * The title for the taxonomy.
+	 */
+	name: string;
+	/**
+	 * An alphanumeric identifier for the taxonomy.
+	 */
+	slug: string;
+	/**
+	 * Whether or not the term cloud should be displayed.
+	 */
+	show_cloud?: boolean;
+	/**
+	 * Types associated with the taxonomy.
+	 */
+	types: string[];
+	/**
+	 * REST base route for the taxonomy.
+	 */
+	rest_base: string;
+	/**
+	 * The visibility settings for the taxonomy.
+	 */
+	visibility?: {
+		/**
+		 * Whether a taxonomy is intended for use publicly either via the admin interface or by front-end users.
+		 */
+		public?: boolean;
+		/**
+		 * Whether the taxonomy is publicly queryable.
+		 */
+		publicly_queryable?: boolean;
+		/**
+		 * Whether to generate a default UI for managing this taxonomy.
+		 */
+		show_ui?: boolean;
+		/**
+		 * Whether to allow automatic creation of taxonomy columns on associated post-types table.
+		 */
+		show_admin_column?: boolean;
+		/**
+		 * Whether to make the taxonomy available for selection in navigation menus.
+		 */
+		show_in_nav_menus?: boolean;
+		/**
+		 * Whether to show the taxonomy in the quick/bulk edit panel.
+		 */
+		show_in_quick_edit?: boolean;
+	};
+	_links?: WP_REST_API_Object_Links;
 	[k: string]: unknown;
 }
 /**

--- a/packages/wp-types/readme.md
+++ b/packages/wp-types/readme.md
@@ -45,6 +45,8 @@ Schema                       | Applies to
 `WP_REST_API_Attachment`     | /wp/v2/media/{id}
 `WP_REST_API_Search_Results` | /wp/v2/search
 `WP_REST_API_Search_Result`  | /wp/v2/search
+`WP_REST_API_Taxonomies`     | /wp/v2/taxonomies
+`WP_REST_API_Taxonomy`       | /wp/v2/taxonomies/{taxonomy}
 `WP_REST_API_Error`          | Any REST API error
 `WP_REST_API_Envelope<T>`    | Any enveloped REST API response
 

--- a/readme.md
+++ b/readme.md
@@ -49,6 +49,8 @@ Schema                       | Applies to
 `WP_REST_API_Attachment`     | /wp/v2/media/{id}
 `WP_REST_API_Search_Results` | /wp/v2/search
 `WP_REST_API_Search_Result`  | /wp/v2/search
+`WP_REST_API_Taxonomies`     | /wp/v2/taxonomies
+`WP_REST_API_Taxonomy`       | /wp/v2/taxonomies/{taxonomy}
 `WP_REST_API_Error`          | Any REST API error
 
 The REST API schemas use JSON Hyper-Schema.

--- a/schema.json
+++ b/schema.json
@@ -95,6 +95,12 @@
 				"Search_Results" : {
 					"$ref": "schemas/rest-api/search-results.json"
 				},
+				"Taxonomy" : {
+					"$ref": "schemas/rest-api/taxonomy.json"
+				},
+				"Taxonomies" : {
+					"$ref": "schemas/rest-api/taxonomies.json"
+				},
 				"Error" : {
 					"$ref": "schemas/rest-api/error.json"
 				}
@@ -116,6 +122,8 @@
 				"Users",
 				"Search_Result",
 				"Search_Results",
+				"Taxonomy",
+				"Taxonomies",
 				"Error"
 			],
 			"additionalProperties": false

--- a/schemas/rest-api/taxonomies.json
+++ b/schemas/rest-api/taxonomies.json
@@ -1,0 +1,19 @@
+{
+	"$schema": "http://json-schema.org/draft-07/hyper-schema#",
+	"$id": "https://raw.githubusercontent.com/johnbillion/wp-json-schemas/trunk/schemas/rest-api/taxonomies.json",
+	"title": "WP_REST_API_Taxonomies",
+	"description": "A collection of taxonomy objects in a REST API context.",
+	"type": "array",
+	"items": {
+		"$ref": "taxonomy.json"
+	},
+	"links": [
+		{
+			"rel": "self",
+			"href": "/wp/v2/taxonomies",
+			"targetSchema": {
+				"$ref": "#"
+			}
+		}
+	]
+}

--- a/schemas/rest-api/taxonomies.json
+++ b/schemas/rest-api/taxonomies.json
@@ -3,8 +3,8 @@
 	"$id": "https://raw.githubusercontent.com/johnbillion/wp-json-schemas/trunk/schemas/rest-api/taxonomies.json",
 	"title": "WP_REST_API_Taxonomies",
 	"description": "A collection of taxonomy objects in a REST API context.",
-	"type": "array",
-	"items": {
+	"type": "object",
+	"additionalProperties": {
 		"$ref": "taxonomy.json"
 	},
 	"links": [

--- a/schemas/rest-api/taxonomy.json
+++ b/schemas/rest-api/taxonomy.json
@@ -1,0 +1,83 @@
+{
+	"$schema": "http://json-schema.org/draft-07/hyper-schema#",
+	"$id": "https://raw.githubusercontent.com/johnbillion/wp-json-schemas/trunk/schemas/rest-api/taxonomy.json",
+	"title": "WP_REST_API_Taxonomy",
+	"description": "A taxonomy in a REST API context.",
+	"type": "object",
+	"required": ["description", "hierarchical", "name", "slug", "types", "rest_base"],
+	"properties": {
+		"capabilities":{
+			"description":"All capabilities used by the taxonomy.",
+			"type":"object"
+		},
+		"description":{
+			"description":"A human-readable description of the taxonomy.",
+			"type":"string"
+		},
+		"hierarchical":{
+			"description":"Whether or not the taxonomy should have children.",
+			"type":"boolean"
+		},
+		"labels":{
+			"description":"Human-readable labels for the taxonomy for various contexts.",
+			"type":"object"
+		},
+		"name":{
+			"description":"The title for the taxonomy.",
+			"type":"string"
+		},
+		"slug":{
+			"description":"An alphanumeric identifier for the taxonomy.",
+			"type":"string"
+		},
+		"show_cloud":{
+			"description":"Whether or not the term cloud should be displayed.",
+			"type":"boolean"
+		},
+		"types":{
+			"description":"Types associated with the taxonomy.",
+			"type":"array",
+			"items":{
+				"type":"string"
+			}
+		},
+		"rest_base":{
+			"description":"REST base route for the taxonomy.",
+			"type":"string"
+		},
+		"visibility":{
+			"description":"The visibility settings for the taxonomy.",
+			"type":"object",
+			"properties":{
+				"public":{
+					"description":"Whether a taxonomy is intended for use publicly either via the admin interface or by front-end users.",
+					"type":"boolean"
+				},
+				"publicly_queryable":{
+					"description":"Whether the taxonomy is publicly queryable.",
+					"type":"boolean"
+				},
+				"show_ui":{
+					"description":"Whether to generate a default UI for managing this taxonomy.",
+					"type":"boolean"
+				},
+				"show_admin_column":{
+					"description":"Whether to allow automatic creation of taxonomy columns on associated post-types table.",
+					"type":"boolean"
+				},
+				"show_in_nav_menus":{
+					"description":"Whether to make the taxonomy available for selection in navigation menus.",
+					"type":"boolean"
+				},
+				"show_in_quick_edit":{
+					"description":"Whether to show the taxonomy in the quick\/bulk edit panel.",
+					"type":"boolean"
+				}
+			},
+			"additionalProperties": false
+		},
+		"_links": {
+			"$ref": "properties/object-links.json"
+		}
+	}
+}

--- a/schemas/rest-api/taxonomy.json
+++ b/schemas/rest-api/taxonomy.json
@@ -4,7 +4,7 @@
 	"title": "WP_REST_API_Taxonomy",
 	"description": "A taxonomy in a REST API context.",
 	"type": "object",
-	"required": ["description", "hierarchical", "name", "slug", "types", "rest_base"],
+	"required": ["description", "hierarchical", "name", "slug", "types", "rest_base", "_links"],
 	"properties": {
 		"capabilities":{
 			"description":"All capabilities used by the taxonomy.",

--- a/schemas/rest-api/taxonomy.json
+++ b/schemas/rest-api/taxonomy.json
@@ -4,74 +4,82 @@
 	"title": "WP_REST_API_Taxonomy",
 	"description": "A taxonomy in a REST API context.",
 	"type": "object",
-	"required": ["description", "hierarchical", "name", "slug", "types", "rest_base", "_links"],
+	"required": [
+		"description",
+		"hierarchical",
+		"name",
+		"slug",
+		"types",
+		"rest_base",
+		"_links"
+	],
 	"properties": {
-		"capabilities":{
-			"description":"All capabilities used by the taxonomy.",
-			"type":"object"
+		"capabilities": {
+			"description": "All capabilities used by the taxonomy.",
+			"type": "object"
 		},
-		"description":{
-			"description":"A human-readable description of the taxonomy.",
-			"type":"string"
+		"description": {
+			"description": "A human-readable description of the taxonomy.",
+			"type": "string"
 		},
-		"hierarchical":{
-			"description":"Whether or not the taxonomy should have children.",
-			"type":"boolean"
+		"hierarchical": {
+			"description": "Whether or not the taxonomy should have children.",
+			"type": "boolean"
 		},
-		"labels":{
-			"description":"Human-readable labels for the taxonomy for various contexts.",
-			"type":"object"
+		"labels": {
+			"description": "Human-readable labels for the taxonomy for various contexts.",
+			"type": "object"
 		},
-		"name":{
-			"description":"The title for the taxonomy.",
-			"type":"string"
+		"name": {
+			"description": "The title for the taxonomy.",
+			"type": "string"
 		},
-		"slug":{
-			"description":"An alphanumeric identifier for the taxonomy.",
-			"type":"string"
+		"slug": {
+			"description": "An alphanumeric identifier for the taxonomy.",
+			"type": "string"
 		},
-		"show_cloud":{
-			"description":"Whether or not the term cloud should be displayed.",
-			"type":"boolean"
+		"show_cloud": {
+			"description": "Whether or not the term cloud should be displayed.",
+			"type": "boolean"
 		},
-		"types":{
-			"description":"Types associated with the taxonomy.",
-			"type":"array",
-			"items":{
-				"type":"string"
+		"types": {
+			"description": "Types associated with the taxonomy.",
+			"type": "array",
+			"items": {
+				"type": "string"
 			}
 		},
-		"rest_base":{
-			"description":"REST base route for the taxonomy.",
-			"type":"string"
+		"rest_base": {
+			"description": "REST base route for the taxonomy.",
+			"type": "string"
 		},
-		"visibility":{
-			"description":"The visibility settings for the taxonomy.",
-			"type":"object",
-			"properties":{
-				"public":{
-					"description":"Whether a taxonomy is intended for use publicly either via the admin interface or by front-end users.",
-					"type":"boolean"
+		"visibility": {
+			"description": "The visibility settings for the taxonomy.",
+			"type": "object",
+			"properties": {
+				"public": {
+					"description": "Whether a taxonomy is intended for use publicly either via the admin interface or by front-end users.",
+					"type": "boolean"
 				},
-				"publicly_queryable":{
-					"description":"Whether the taxonomy is publicly queryable.",
-					"type":"boolean"
+				"publicly_queryable": {
+					"description": "Whether the taxonomy is publicly queryable.",
+					"type": "boolean"
 				},
-				"show_ui":{
-					"description":"Whether to generate a default UI for managing this taxonomy.",
-					"type":"boolean"
+				"show_ui": {
+					"description": "Whether to generate a default UI for managing this taxonomy.",
+					"type": "boolean"
 				},
-				"show_admin_column":{
-					"description":"Whether to allow automatic creation of taxonomy columns on associated post-types table.",
-					"type":"boolean"
+				"show_admin_column": {
+					"description": "Whether to allow automatic creation of taxonomy columns on associated post-types table.",
+					"type": "boolean"
 				},
-				"show_in_nav_menus":{
-					"description":"Whether to make the taxonomy available for selection in navigation menus.",
-					"type":"boolean"
+				"show_in_nav_menus": {
+					"description": "Whether to make the taxonomy available for selection in navigation menus.",
+					"type": "boolean"
 				},
-				"show_in_quick_edit":{
-					"description":"Whether to show the taxonomy in the quick\/bulk edit panel.",
-					"type":"boolean"
+				"show_in_quick_edit": {
+					"description": "Whether to show the taxonomy in the quick/bulk edit panel.",
+					"type": "boolean"
 				}
 			},
 			"additionalProperties": false

--- a/tests/mu-plugins/mu-plugin.php
+++ b/tests/mu-plugins/mu-plugin.php
@@ -220,8 +220,10 @@ WP_CLI::add_command( 'json-dump search-results', function() : void {
 /**
  * Test data for REST API taxonomies.
  */
-WP_CLI::add_command( 'json-dump taxonomy', function() : void {
+WP_CLI::add_command( 'json-dump taxonomies', function() : void {
 	$data = get_rest_response( 'GET', '/wp/v2/taxonomies' );
 
-	save( $data, 'rest-api/taxonomy' );
+	save_rest( [
+		$data
+	], 'rest-api/taxonomies' );
 } );

--- a/tests/mu-plugins/mu-plugin.php
+++ b/tests/mu-plugins/mu-plugin.php
@@ -189,3 +189,12 @@ WP_CLI::add_command( 'json-dump search-result', function() : void {
 
 	save( $data, 'rest-api/search-result' );
 } );
+
+/**
+ * Test data for REST API taxonomies.
+ */
+WP_CLI::add_command( 'json-dump taxonomy', function() : void {
+	$data = get_rest_response( 'GET', '/wp/v2/taxonomies' );
+
+	save( $data, 'rest-api/taxonomy' );
+} );

--- a/tests/mu-plugins/mu-plugin.php
+++ b/tests/mu-plugins/mu-plugin.php
@@ -5,6 +5,7 @@ namespace WPJsonSchemas;
 use WP_CLI;
 use WP_Error;
 use WP_REST_Request;
+use WP_REST_Response;
 
 if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
 	return;
@@ -16,7 +17,7 @@ if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
  * @param mixed[] $data Array of test data objects.
  * @param string  $dir  The directory to save the files.
  */
-function save( array $data, string $dir ) : void {
+function save_array( array $data, string $dir ) : void {
 	$dir = dirname( ABSPATH ) . '/data/' . $dir;
 
 	if ( ! file_exists( $dir ) ) {
@@ -31,18 +32,40 @@ function save( array $data, string $dir ) : void {
 }
 
 /**
- * Helper function for performing an internal REST API request and returning its repsonse data.
+ * Saves an array of REST API responses as JSON ready for validating against a schema.
+ *
+ * @param WP_REST_Response[] $data Array of responses to a REST API request.
+ * @param string             $dir  The directory to save the files.
+ */
+function save_rest( array $data, string $dir ) : void {
+	$dir = dirname( ABSPATH ) . '/data/' . $dir;
+
+	if ( ! file_exists( $dir ) ) {
+		mkdir( $dir, 0777, true );
+	}
+
+	foreach ( $data as $i => $item ) {
+		$save = rest_get_server()->response_to_data( $item, false );
+
+		$json = json_encode( $save, JSON_PRETTY_PRINT ^ JSON_UNESCAPED_SLASHES );
+
+		file_put_contents( $dir . '/' . $i . '.json', $json );
+	}
+}
+
+/**
+ * Helper function for performing an internal REST API request and returning its response data.
  *
  * @param string $method The HTTP method such as `GET` or `POST`.
  * @param string $path   The REST API endpoint such as `wp/v2/posts`.
  * @param array $params  Array of query parameters for the request.
- * @return mixed[] The response data.
+ * @return WP_Rest_Response The response data.
  */
 function get_rest_response( string $method, string $path, array $params = [] ) {
 	$request = new WP_REST_Request( $method, $path );
 	$request->set_query_params( $params );
 
-	return rest_get_server()->response_to_data( rest_do_request( $request ), false );
+	return rest_do_request( $request );
 }
 
 /**
@@ -61,13 +84,15 @@ WP_CLI::add_command( 'json-dump post', function() : void {
 		'order'          => 'ASC',
 	] );
 
-	save( $posts, 'post' );
+	save_array( $posts, 'post' );
 
 	$data = get_rest_response( 'GET', '/wp/v2/posts', [
 		'per_page' => 100,
 	] );
 
-	save( $data, 'rest-api/post' );
+	save_rest( [
+		$data
+	], 'rest-api/posts' );
 } );
 
 /**
@@ -80,7 +105,7 @@ WP_CLI::add_command( 'json-dump user', function() : void {
 		'order'   => 'ASC',
 	] );
 
-	save( $users, 'user' );
+	save_array( $users, 'user' );
 } );
 
 /**
@@ -94,7 +119,7 @@ WP_CLI::add_command( 'json-dump tag', function() : void {
 		'order'    => 'ASC',
 	] );
 
-	save( $tags, 'tag' );
+	save_array( $tags, 'tag' );
 } );
 
 /**
@@ -108,7 +133,7 @@ WP_CLI::add_command( 'json-dump category', function() : void {
 		'order'    => 'ASC',
 	] );
 
-	save( $categories, 'category' );
+	save_array( $categories, 'category' );
 } );
 
 /**
@@ -121,7 +146,7 @@ WP_CLI::add_command( 'json-dump comment', function() : void {
 		'order'   => 'ASC',
 	] );
 
-	save( $comment, 'comment' );
+	save_array( $comment, 'comment' );
 } );
 
 /**
@@ -176,16 +201,18 @@ WP_CLI::add_command( 'json-dump error', function() : void {
 	$multi_code_1->merge_from( $multi_code_2 );
 	$errors[] = $multi_code_1;
 
-	save( $errors, 'error' );
+	save_array( $errors, 'error' );
 } );
 
 /**
  * Test data for REST API search results.
  */
-WP_CLI::add_command( 'json-dump search-result', function() : void {
+WP_CLI::add_command( 'json-dump search-results', function() : void {
 	$data = get_rest_response( 'GET', '/wp/v2/search', [
 		'per_page' => 100,
 	] );
 
-	save( $data, 'rest-api/search-result' );
+	save_rest( [
+		$data
+	], 'rest-api/search-results' );
 } );


### PR DESCRIPTION
### Description

Resolves #14

This PR includes the following:

- New schema: `WP_REST_API_Taxonomy`
- New schema: `WP_REST_API_Taxonomies` (which references `WP_REST_API_Taxonomy`)
- Docs update: `CONTRIBUTING.md` now includes instructions for modifying both `package.json` and `composer.json` when adding new tests.

### Tests

I followed the updated instructions in `CONTRIBUTING.md` and ran the following tests successfully:

- [x] `composer run test`

