### PR TITLE
Add schemas for WP REST API types

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,9 @@
 			"npm run test-user",
 			"wp json-dump search-result",
 			"npm run test-rest-api-search-result",
-			"npm run test-rest-api-post"
+			"npm run test-rest-api-post",
+			"wp json-dump type",
+			"npm run test-rest-api-type"
 		]
 	},
 	"funding": [

--- a/composer.json
+++ b/composer.json
@@ -52,8 +52,8 @@
 			"npm run test-rest-api-posts",
 			"wp json-dump taxonomies",
 			"npm run test-rest-api-taxonomies",
-			"wp json-dump type",
-			"npm run test-rest-api-type"
+			"wp json-dump types",
+			"npm run test-rest-api-types"
 		]
 	},
 	"funding": [

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 		"test-error": "ajv validate -m tests/hyper-schema.json -s schemas/error.json -d \"tests/data/error/*.json\" -r \"schemas/**/*.json\"",
 		"test-rest-api-posts": "ajv validate -m tests/hyper-schema.json -s schemas/rest-api/posts.json -d \"tests/data/rest-api/posts/*.json\" -r \"schemas/**/*.json\"",
 		"test-rest-api-search-results": "ajv validate -m tests/hyper-schema.json -s schemas/rest-api/search-results.json -d \"tests/data/rest-api/search-results/*.json\" -r \"schemas/**/*.json\"",
-		"test-rest-api-type": "ajv validate -m tests/hyper-schema.json -s schemas/rest-api/type.json -d \"tests/data/rest-api/type/*.json\" -r \"schemas/**/*.json\"",
+		"test-rest-api-types": "ajv validate -m tests/hyper-schema.json -s schemas/rest-api/types.json -d \"tests/data/rest-api/types/*.json\" -r \"schemas/**/*.json\"",
 		"test-rest-api-taxonomies": "ajv validate -m tests/hyper-schema.json -s schemas/rest-api/taxonomies.json -d \"tests/data/rest-api/taxonomies/*.json\" -r \"schemas/**/*.json\"",
 		"validate": "ajv compile -m tests/hyper-schema.json -s schema.json -r \"schemas/**/*.json\""
 	}

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
 		"test-error": "ajv validate -m tests/hyper-schema.json -s schemas/error.json -d \"tests/data/error/*.json\" -r \"schemas/**/*.json\"",
 		"test-rest-api-post": "ajv validate -m tests/hyper-schema.json -s schemas/rest-api/post.json -d \"tests/data/rest-api/post/*.json\" -r \"schemas/**/*.json\"",
 		"test-rest-api-search-result": "ajv validate -m tests/hyper-schema.json -s schemas/rest-api/search-result.json -d \"tests/data/rest-api/search-result/*.json\" -r \"schemas/**/*.json\"",
+		"test-rest-api-type": "ajv validate -m tests/hyper-schema.json -s schemas/rest-api/type.json -d \"tests/data/rest-api/type/*.json\" -r \"schemas/**/*.json\"",
 		"validate": "ajv compile -m tests/hyper-schema.json -s schema.json -r \"schemas/**/*.json\""
 	}
 }

--- a/packages/wp-types/index.ts
+++ b/packages/wp-types/index.ts
@@ -61,6 +61,10 @@ export type WP_REST_API_Users = WP_REST_API_User[];
  * A collection of search result objects in a REST API context.
  */
 export type WP_REST_API_Search_Results = WP_REST_API_Search_Result[];
+/**
+ * A collection of type records in a REST API context.
+ */
+export type WP_REST_API_Types = WP_REST_API_Type[];
 
 /**
  * WordPress is open source software you can use to create a beautiful website, blog, or app.
@@ -96,6 +100,8 @@ export interface WP {
 		Users: WP_REST_API_Users;
 		Search_Result: WP_REST_API_Search_Result;
 		Search_Results: WP_REST_API_Search_Results;
+		Type: WP_REST_API_Type;
+		Types: WP_REST_API_Types;
 		Error: WP_REST_API_Error;
 	};
 }
@@ -1864,6 +1870,59 @@ export interface WP_REST_API_Search_Result {
 	 * Object subtype.
 	 */
 	subtype: WP_Post_Type_Name | WP_Taxonomy_Name | string;
+	_links: WP_REST_API_Object_Links;
+	[k: string]: unknown;
+}
+/**
+ * A type record in a REST API context.
+ */
+export interface WP_REST_API_Type {
+	/**
+	 * All capabilities used by the post type.
+	 */
+	capabilities?: {
+		[k: string]: unknown;
+	};
+	/**
+	 * A human-readable description of the post type.
+	 */
+	description: string;
+	/**
+	 * Whether or not the post type should have children.
+	 */
+	hierarchical: boolean;
+	/**
+	 * Whether or not the post type can be viewed.
+	 */
+	viewable?: boolean;
+	/**
+	 * Human-readable labels for the post type for various contexts.
+	 */
+	labels?: {
+		[k: string]: unknown;
+	};
+	/**
+	 * The title for the post type.
+	 */
+	name: string;
+	/**
+	 * An alphanumeric identifier for the post type.
+	 */
+	slug: string;
+	/**
+	 * All features, supported by the post type.
+	 */
+	supports?: {
+		[k: string]: unknown;
+	};
+	/**
+	 * Taxonomies associated with post type.
+	 */
+	taxonomies: string[];
+	/**
+	 * REST base route for the post type.
+	 */
+	rest_base: string;
 	_links: WP_REST_API_Object_Links;
 	[k: string]: unknown;
 }

--- a/packages/wp-types/readme.md
+++ b/packages/wp-types/readme.md
@@ -45,6 +45,8 @@ Schema                       | Applies to
 `WP_REST_API_Attachment`     | /wp/v2/media/{id}
 `WP_REST_API_Search_Results` | /wp/v2/search
 `WP_REST_API_Search_Result`  | /wp/v2/search
+`WP_REST_API_Types`          | /wp/v2/types
+`WP_REST_API_Type`           | /wp/v2/types/{type}
 `WP_REST_API_Error`          | Any REST API error
 `WP_REST_API_Envelope<T>`    | Any enveloped REST API response
 

--- a/readme.md
+++ b/readme.md
@@ -49,6 +49,8 @@ Schema                       | Applies to
 `WP_REST_API_Attachment`     | /wp/v2/media/{id}
 `WP_REST_API_Search_Results` | /wp/v2/search
 `WP_REST_API_Search_Result`  | /wp/v2/search
+`WP_REST_API_Types`          | /wp/v2/types
+`WP_REST_API_Type`           | /wp/v2/types/{type}
 `WP_REST_API_Error`          | Any REST API error
 
 The REST API schemas use JSON Hyper-Schema.

--- a/schema.json
+++ b/schema.json
@@ -95,6 +95,12 @@
 				"Search_Results" : {
 					"$ref": "schemas/rest-api/search-results.json"
 				},
+				"Type" : {
+					"$ref": "schemas/rest-api/type.json"
+				},
+				"Types" : {
+					"$ref": "schemas/rest-api/types.json"
+				},
 				"Error" : {
 					"$ref": "schemas/rest-api/error.json"
 				}
@@ -116,6 +122,8 @@
 				"Users",
 				"Search_Result",
 				"Search_Results",
+				"Type",
+				"Types",
 				"Error"
 			],
 			"additionalProperties": false

--- a/schemas/rest-api/type.json
+++ b/schemas/rest-api/type.json
@@ -1,0 +1,64 @@
+{
+	"$schema": "http://json-schema.org/draft-07/hyper-schema#",
+	"$id": "https://raw.githubusercontent.com/johnbillion/wp-json-schemas/trunk/schemas/rest-api/type.json",
+	"title": "WP_REST_API_Type",
+	"description": "A type record in a REST API context.",
+	"type": "object",
+	"required": [
+		"description",
+		"hierarchical",
+		"name",
+		"slug",
+		"taxonomies",
+		"rest_base",
+		"_links"
+	],
+	"properties": {
+		"capabilities": {
+			"description": "All capabilities used by the post type.",
+			"type": "object"
+		},
+		"description": {
+			"description": "A human-readable description of the post type.",
+			"type": "string"
+		},
+		"hierarchical": {
+			"description": "Whether or not the post type should have children.",
+			"type": "boolean"
+		},
+		"viewable": {
+			"description": "Whether or not the post type can be viewed.",
+			"type": "boolean"
+		},
+		"labels": {
+			"description": "Human-readable labels for the post type for various contexts.",
+			"type": "object"
+		},
+		"name": {
+			"description": "The title for the post type.",
+			"type": "string"
+		},
+		"slug": {
+			"description": "An alphanumeric identifier for the post type.",
+			"type": "string"
+		},
+		"supports": {
+			"description": "All features, supported by the post type.",
+			"type": "object"
+		},
+		"taxonomies": {
+			"description": "Taxonomies associated with post type.",
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
+		},
+		"rest_base": {
+			"description": "REST base route for the post type.",
+			"type": "string"
+		},
+		"_links": {
+			"$ref": "properties/object-links.json"
+		}
+	}
+}

--- a/schemas/rest-api/types.json
+++ b/schemas/rest-api/types.json
@@ -1,0 +1,19 @@
+{
+	"$schema": "http://json-schema.org/draft-07/hyper-schema#",
+	"$id": "https://raw.githubusercontent.com/johnbillion/wp-json-schemas/trunk/schemas/rest-api/types.json",
+	"title": "WP_REST_API_Types",
+	"description": "A collection of type records in a REST API context.",
+	"type": "array",
+	"items": {
+		"$ref": "type.json"
+	},
+	"links": [
+		{
+			"rel": "self",
+			"href": "/wp/v2/types",
+			"targetSchema": {
+				"$ref": "#"
+			}
+		}
+	]
+}

--- a/schemas/rest-api/types.json
+++ b/schemas/rest-api/types.json
@@ -3,8 +3,8 @@
 	"$id": "https://raw.githubusercontent.com/johnbillion/wp-json-schemas/trunk/schemas/rest-api/types.json",
 	"title": "WP_REST_API_Types",
 	"description": "A collection of type records in a REST API context.",
-	"type": "array",
-	"items": {
+	"type": "object",
+	"additionalProperties": {
 		"$ref": "type.json"
 	},
 	"links": [

--- a/tests/mu-plugins/mu-plugin.php
+++ b/tests/mu-plugins/mu-plugin.php
@@ -231,8 +231,10 @@ WP_CLI::add_command( 'json-dump taxonomies', function() : void {
 /**
  * Test data for REST API types.
  */
-WP_CLI::add_command( 'json-dump type', function() : void {
+WP_CLI::add_command( 'json-dump types', function() : void {
 	$data = get_rest_response( 'GET', '/wp/v2/types' );
 
-	save( $data, 'rest-api/type' );
+	save_rest( [
+		$data
+	], 'rest-api/types' );
 } );

--- a/tests/mu-plugins/mu-plugin.php
+++ b/tests/mu-plugins/mu-plugin.php
@@ -189,3 +189,12 @@ WP_CLI::add_command( 'json-dump search-result', function() : void {
 
 	save( $data, 'rest-api/search-result' );
 } );
+
+/**
+ * Test data for REST API types.
+ */
+WP_CLI::add_command( 'json-dump type', function() : void {
+	$data = get_rest_response( 'GET', '/wp/v2/types' );
+
+	save( $data, 'rest-api/type' );
+} );


### PR DESCRIPTION
### Description

Resolves #12 

This PR includes the following:

- New schema: `WP_REST_API_Type`
- New schema: `WP_REST_API_Types` (which references `WP_REST_API_Type`)

### Tests

I followed the updated instructions in `CONTRIBUTING.md` and ran the following tests successfully:

- [x] `composer run test`

