### PR TITLE
REST API context

### DIFF
--- a/tests/mu-plugins/mu-plugin.php
+++ b/tests/mu-plugins/mu-plugin.php
@@ -44,9 +44,10 @@ function save_rest( array $data, string $dir ) : void {
 		mkdir( $dir, 0777, true );
 	}
 
-	foreach ( $data as $i => $item ) {
-		$save = rest_get_server()->response_to_data( $item, false );
+	$server = rest_get_server();
 
+	foreach ( $data as $i => $item ) {
+		$save = $server->response_to_data( $item, false );
 		$json = json_encode( $save, JSON_PRETTY_PRINT ^ JSON_UNESCAPED_SLASHES );
 
 		file_put_contents( $dir . '/' . $i . '.json', $json );

--- a/tests/mu-plugins/mu-plugin.php
+++ b/tests/mu-plugins/mu-plugin.php
@@ -87,6 +87,7 @@ WP_CLI::add_command( 'json-dump post', function() : void {
 	save_array( $posts, 'post' );
 
 	$data = get_rest_response( 'GET', '/wp/v2/posts', [
+		'context' => 'edit',
 		'per_page' => 100,
 	] );
 
@@ -209,6 +210,7 @@ WP_CLI::add_command( 'json-dump error', function() : void {
  */
 WP_CLI::add_command( 'json-dump search-results', function() : void {
 	$data = get_rest_response( 'GET', '/wp/v2/search', [
+		'context' => 'view',
 		'per_page' => 100,
 	] );
 
@@ -221,7 +223,9 @@ WP_CLI::add_command( 'json-dump search-results', function() : void {
  * Test data for REST API taxonomies.
  */
 WP_CLI::add_command( 'json-dump taxonomies', function() : void {
-	$data = get_rest_response( 'GET', '/wp/v2/taxonomies' );
+	$data = get_rest_response( 'GET', '/wp/v2/taxonomies', [
+		'context' => 'edit',
+	] );
 
 	save_rest( [
 		$data

--- a/tests/mu-plugins/mu-plugin.php
+++ b/tests/mu-plugins/mu-plugin.php
@@ -11,6 +11,15 @@ if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
 	return;
 }
 
+if ( defined( 'WP_INSTALLING' ) && WP_INSTALLING ) {
+	return;
+}
+
+add_action( 'init', function() : void {
+	// Ensure we're authenticated as an admin during test data generation.
+	wp_set_current_user( 1 );
+} );
+
 /**
  * Saves an array of test data as JSON in files ready for validating against a schema.
  *

--- a/tests/mu-plugins/mu-plugin.php
+++ b/tests/mu-plugins/mu-plugin.php
@@ -237,7 +237,9 @@ WP_CLI::add_command( 'json-dump taxonomies', function() : void {
  * Test data for REST API types.
  */
 WP_CLI::add_command( 'json-dump types', function() : void {
-	$data = get_rest_response( 'GET', '/wp/v2/types' );
+	$data = get_rest_response( 'GET', '/wp/v2/types', [
+		'context' => 'view',
+	] );
 
 	save_rest( [
 		$data


### PR DESCRIPTION
See #33.

This implements `edit` context where possible during REST API test data generation.