### PR TITLE
Introduce a dedicated schema for `wp/v2/pages`

### DIFF
--- a/packages/wp-types/index.ts
+++ b/packages/wp-types/index.ts
@@ -118,8 +118,8 @@ export interface WP {
 		Comments: WP_REST_API_Comments;
 		Post: WP_REST_API_Post;
 		Posts: WP_REST_API_Posts;
-		Page?: WP_REST_API_Page;
-		Pages?: WP_REST_API_Pages;
+		Page: WP_REST_API_Page;
+		Pages: WP_REST_API_Pages;
 		Attachment: WP_REST_API_Attachment;
 		Attachments: WP_REST_API_Attachments;
 		Block: WP_REST_API_Block;

--- a/packages/wp-types/index.ts
+++ b/packages/wp-types/index.ts
@@ -30,6 +30,14 @@ export type WP_REST_API_Comments = WP_REST_API_Comment[];
  */
 export type WP_REST_API_Posts = WP_REST_API_Post[];
 /**
+ * A page object in a REST API context.
+ */
+export type WP_REST_API_Page = WP_REST_API_Post;
+/**
+ * A collection of page objects in a REST API context.
+ */
+export type WP_REST_API_Pages = WP_REST_API_Page[];
+/**
  * A collection of media attachment objects in a REST API context.
  */
 export type WP_REST_API_Attachments = WP_REST_API_Attachment[];
@@ -110,6 +118,8 @@ export interface WP {
 		Comments: WP_REST_API_Comments;
 		Post: WP_REST_API_Post;
 		Posts: WP_REST_API_Posts;
+		Page?: WP_REST_API_Page;
+		Pages?: WP_REST_API_Pages;
 		Attachment: WP_REST_API_Attachment;
 		Attachments: WP_REST_API_Attachments;
 		Block: WP_REST_API_Block;

--- a/packages/wp-types/readme.md
+++ b/packages/wp-types/readme.md
@@ -71,8 +71,8 @@ Route                                                   | Schema
 /wp/v2/navigation/{parent}/autosaves/{id}               | Todo
 /wp/v2/navigation/{parent}/revisions                    | Todo
 /wp/v2/navigation/{parent}/revisions/{id}               | Todo
-/wp/v2/pages                                            | `WP_REST_API_Posts`
-/wp/v2/pages/{id}                                       | `WP_REST_API_Post`
+/wp/v2/pages                                            | `WP_REST_API_Pages`
+/wp/v2/pages/{id}                                       | `WP_REST_API_Page`
 /wp/v2/pages/{id}/autosaves                             | Todo
 /wp/v2/pages/{parent}/autosaves/{id}                    | Todo
 /wp/v2/pages/{parent}/revisions                         | `WP_REST_API_Revisions`

--- a/readme.md
+++ b/readme.md
@@ -75,8 +75,8 @@ Route                                                   | Schema
 /wp/v2/navigation/{parent}/autosaves/{id}               | Todo
 /wp/v2/navigation/{parent}/revisions                    | Todo
 /wp/v2/navigation/{parent}/revisions/{id}               | Todo
-/wp/v2/pages                                            | `WP_REST_API_Posts`
-/wp/v2/pages/{id}                                       | `WP_REST_API_Post`
+/wp/v2/pages                                            | `WP_REST_API_Pages`
+/wp/v2/pages/{id}                                       | `WP_REST_API_Page`
 /wp/v2/pages/{id}/autosaves                             | Todo
 /wp/v2/pages/{parent}/autosaves/{id}                    | Todo
 /wp/v2/pages/{parent}/revisions                         | `WP_REST_API_Revisions`

--- a/schema.json
+++ b/schema.json
@@ -65,6 +65,12 @@
 				"Posts": {
 					"$ref": "schemas/rest-api/posts.json"
 				},
+				"Page": {
+					"$ref": "schemas/rest-api/page.json"
+				},
+				"Pages": {
+					"$ref": "schemas/rest-api/pages.json"
+				},
 				"Attachment": {
 					"$ref": "schemas/rest-api/attachment.json"
 				},

--- a/schema.json
+++ b/schema.json
@@ -170,6 +170,8 @@
 				"Comments",
 				"Post",
 				"Posts",
+				"Page",
+				"Pages",
 				"Attachment",
 				"Attachments",
 				"Block_Directory_Item",

--- a/schemas/rest-api/page.json
+++ b/schemas/rest-api/page.json
@@ -1,0 +1,85 @@
+{
+	"$schema": "http://json-schema.org/draft-07/hyper-schema#",
+	"$id": "https://raw.githubusercontent.com/johnbillion/wp-json-schemas/trunk/schemas/rest-api/page.json",
+	"title": "WP_REST_API_Page",
+	"description": "A page object in a REST API context.",
+	"allOf": [
+		{
+			"$ref": "post.json"
+		}
+	],
+	"links": [
+		{
+			"rel": "self",
+			"href": "/wp/v2/pages/{id}",
+			"hrefSchema": {
+				"properties": {
+					"id": {
+						"$ref": "post.json#/properties/id"
+					}
+				}
+			},
+			"targetSchema": {
+				"$ref": "#"
+			}
+		},
+		{
+			"rel": "collection",
+			"href": "/wp/v2/pages",
+			"targetSchema": {
+				"type": "array",
+				"items": {
+					"$ref": "#"
+				}
+			}
+		},
+		{
+			"rel": "author",
+			"href": "/wp/v2/users/{author}",
+			"hrefSchema": {
+				"properties": {
+					"author": {
+						"$ref": "post.json#/properties/author"
+					}
+				}
+			},
+			"targetSchema": {
+				"$ref": "user.json"
+			}
+		},
+		{
+			"rel": "replies",
+			"href": "/wp/v2/comments?post={id}",
+			"hrefSchema": {
+				"properties": {
+					"id": {
+						"$ref": "post.json#/properties/id"
+					}
+				}
+			},
+			"targetSchema": {
+				"type": "array",
+				"items": {
+					"$ref": "comment.json"
+				}
+			}
+		},
+		{
+			"rel": "version-history",
+			"href": "/wp/v2/pages/{id}/revisions",
+			"hrefSchema": {
+				"properties": {
+					"id": {
+						"$ref": "post.json#/properties/id"
+					}
+				}
+			},
+			"targetSchema": {
+				"type": "array",
+				"items": {
+					"$ref": "#"
+				}
+			}
+		}
+	]
+}

--- a/schemas/rest-api/pages.json
+++ b/schemas/rest-api/pages.json
@@ -1,0 +1,19 @@
+{
+	"$schema": "http://json-schema.org/draft-07/hyper-schema#",
+	"$id": "https://raw.githubusercontent.com/johnbillion/wp-json-schemas/trunk/schemas/rest-api/pages.json",
+	"title": "WP_REST_API_Pages",
+	"description": "A collection of page objects in a REST API context.",
+	"type": "array",
+	"items": {
+		"$ref": "page.json"
+	},
+	"links": [
+		{
+			"rel": "self",
+			"href": "/wp/v2/pages",
+			"targetSchema": {
+				"$ref": "#"
+			}
+		}
+	]
+}

--- a/tests/bin/test.sh
+++ b/tests/bin/test.sh
@@ -10,11 +10,10 @@ function test_missing_properties() {
 }
 
 function validate_schema() {
-	local schema="$1"
-	local file="${2:-$schema}"
+	local file="$1"
 	local base=${file//schemas\//}
 	local base=${base/.json/}
-	./node_modules/.bin/ajv validate -m tests/hyper-schema/hyper-schema.json -r "schemas/**/*.json" -s "$schema" -d "tests/data/$base/*.json"
+	./node_modules/.bin/ajv validate -m tests/hyper-schema/hyper-schema.json -r "schemas/**/*.json" -s "$file" -d "tests/data/$base/*.json"
 }
 
 for file in schemas/*.json
@@ -28,6 +27,3 @@ do
 	test_missing_properties "$file"
 	validate_schema "$file"
 done
-
-# Validate the wp/v2/pages response against the posts schema
-validate_schema "schemas/rest-api/posts.json" "rest-api/pages"


### PR DESCRIPTION
`wp/v2/pages` is the only REST API endpoint that uses a schema that doesn't match its name. This fixes that.